### PR TITLE
Creation of r.txt for existing projects

### DIFF
--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -419,6 +419,9 @@ def setup(*args, **kwargs):
             output("result: upgrade core4os and project")
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
+        if not os.path.exists(r_requirements):
+            with open(r_requirements, 'a') as file:
+                file.write('mongolite\nfeather')
         with open(r_requirements, 'r') as file:
             data = file.read()
         packages_required = data.split(sep='\n')

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,7 +420,7 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, 'r+', encoding="utf-8") as file:
+            with open(r_requirements, 'w+', encoding="utf-8") as file:
                 file.write('mongolite\nfeather')
         with open(r_requirements, 'r') as file:
             data = file.read()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,7 +420,7 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, "rw") as file:
+            with open(r_requirements, "a") as file:
                 file.write("mongolite\nfeather")
         with open(r_requirements, 'r') as file:
             data = file.read()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,8 +420,8 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, 'a') as file:
-                file.write('mongolite\nfeather')
+            with open(r_requirements, 'a+') as file:
+                file.write("mongolite\nfeather")
         with open(r_requirements, 'r') as file:
             data = file.read()
         packages_required = data.split(sep='\n')

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -428,7 +428,8 @@ def setup(*args, **kwargs):
                 output('Checking package: {}', package)
                 output('Installed?: {}', isinstalled(package, lib_loc=rlib))
                 if not (isinstalled(package, lib_loc=rlib)):
-                    utils.install_packages(package, lib=rlib, verbose=False)
+                    utils.install_packages(package, lib=rlib, verbose=False,
+                                           quiet=True)
         sys.exit(upgrade)
     else:
         check_requirements()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,8 +420,8 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, "w", encoding="utf-8") as file:
-                file.write("mongolite\nfeather")
+            with open(r_requirements, 'awrt', encoding="utf-8") as file:
+                file.write('mongolite\nfeather')
         with open(r_requirements, 'r') as file:
             data = file.read()
         packages_required = data.split(sep='\n')

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -427,7 +427,7 @@ def setup(*args, **kwargs):
             output('Checking package: {}', package)
             output('Installed?: {}', isinstalled(package, lib_loc=rlib))
             if not (isinstalled(package, lib_loc=rlib)):
-                utils.install_packages(package, lib=rlib, verbose=True)
+                utils.install_packages(package, lib=rlib, verbose=False)
         sys.exit(upgrade)
     else:
         check_requirements()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,14 +420,14 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, "a") as file:
-                file.write("mongolite\nfeather")
+            with open(r_requirements, 'a') as file:
+                file.write('mongolite\nfeather')
         with open(r_requirements, 'r') as file:
             data = file.read()
         packages_required = data.split(sep='\n')
         utils = importr('utils')
         for package in packages_required:
-            if package is not None and package != '':
+            if package is not None and package != "":
                 output('Checking package: {}', package)
                 output('Installed?: {}', isinstalled(package, lib_loc=rlib))
                 if not (isinstalled(package, lib_loc=rlib)):

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,7 +420,7 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, 'awrt', encoding="utf-8") as file:
+            with open(r_requirements, 'r+', encoding="utf-8") as file:
                 file.write('mongolite\nfeather')
         with open(r_requirements, 'r') as file:
             data = file.read()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -417,6 +417,17 @@ def setup(*args, **kwargs):
             output("result: upgrade project")
         else:
             output("result: upgrade core4os and project")
+        from rpy2.robjects.packages import importr, isinstalled
+        r_requirements = "r.txt"
+        with open(r_requirements, 'r') as file:
+            data = file.read()
+        packages_required = data.split(sep='\n')
+        utils = importr('utils')
+        for package in packages_required:
+            output('Checking package: {}', package)
+            output('Installed?: {}', isinstalled(package, lib_loc=rlib))
+            if not (isinstalled(package, lib_loc=rlib)):
+                utils.install_packages(package, lib=rlib, verbose=True)
         sys.exit(upgrade)
     else:
         check_requirements()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,8 +420,8 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, 'a') as file:
-                file.write('mongolite\nfeather')
+            with open(r_requirements, "rw") as file:
+                file.write("mongolite\nfeather")
         with open(r_requirements, 'r') as file:
             data = file.read()
         packages_required = data.split(sep='\n')

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,7 +420,7 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, 'a+') as file:
+            with open(r_requirements, "a+", encoding="utf-8") as file:
                 file.write("mongolite\nfeather")
         with open(r_requirements, 'r') as file:
             data = file.read()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -424,10 +424,11 @@ def setup(*args, **kwargs):
         packages_required = data.split(sep='\n')
         utils = importr('utils')
         for package in packages_required:
-            output('Checking package: {}', package)
-            output('Installed?: {}', isinstalled(package, lib_loc=rlib))
-            if not (isinstalled(package, lib_loc=rlib)):
-                utils.install_packages(package, lib=rlib, verbose=False)
+            if package != '':
+                output('Checking package: {}', package)
+                output('Installed?: {}', isinstalled(package, lib_loc=rlib))
+                if not (isinstalled(package, lib_loc=rlib)):
+                    utils.install_packages(package, lib=rlib, verbose=False)
         sys.exit(upgrade)
     else:
         check_requirements()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -423,7 +423,6 @@ def setup(*args, **kwargs):
             data = file.read()
         packages_required = data.split(sep='\n')
         utils = importr('utils')
-        utils.chooseCRANmirror(ind=1)
         for package in packages_required:
             if package is not None:
                 output('Checking package: {}', package)

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -424,7 +424,7 @@ def setup(*args, **kwargs):
         packages_required = data.split(sep='\n')
         utils = importr('utils')
         for package in packages_required:
-            if package is not None:
+            if package is not None and package != '':
                 output('Checking package: {}', package)
                 output('Installed?: {}', isinstalled(package, lib_loc=rlib))
                 if not (isinstalled(package, lib_loc=rlib)):

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -423,6 +423,7 @@ def setup(*args, **kwargs):
             data = file.read()
         packages_required = data.split(sep='\n')
         utils = importr('utils')
+        utils.chooseCRANmirror(ind=1)
         for package in packages_required:
             if package != '':
                 output('Checking package: {}', package)

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -420,7 +420,7 @@ def setup(*args, **kwargs):
         from rpy2.robjects.packages import importr, isinstalled
         r_requirements = "r.txt"
         if not os.path.exists(r_requirements):
-            with open(r_requirements, "a+", encoding="utf-8") as file:
+            with open(r_requirements, "w", encoding="utf-8") as file:
                 file.write("mongolite\nfeather")
         with open(r_requirements, 'r') as file:
             data = file.read()

--- a/core4build/__init__.py
+++ b/core4build/__init__.py
@@ -425,7 +425,7 @@ def setup(*args, **kwargs):
         utils = importr('utils')
         utils.chooseCRANmirror(ind=1)
         for package in packages_required:
-            if package != '':
+            if package is not None:
                 output('Checking package: {}', package)
                 output('Installed?: {}', isinstalled(package, lib_loc=rlib))
                 if not (isinstalled(package, lib_loc=rlib)):


### PR DESCRIPTION
Within each project there should be a r.txt file where you can enter the r packages needed for the respective project so that they can be installed automatically by the core4build process. The standard packages that each project should contain are mongolite and feather. However, if a project has been created before the r.txt has been introduced, this file will not exist. 
The code change of this merge request checks with every build whether the r.txt exists and contains the above mentioned standard packages. If this is not the case, it will be created. 
